### PR TITLE
feat: add favorite activities feature with UI

### DIFF
--- a/drizzle/0009_robust_the_leader.sql
+++ b/drizzle/0009_robust_the_leader.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `activity` ADD `favorite` integer DEFAULT false NOT NULL;

--- a/drizzle/meta/0009_snapshot.json
+++ b/drizzle/meta/0009_snapshot.json
@@ -1,0 +1,705 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "a832f8ec-6613-443d-95a6-14b995ea453e",
+  "prevId": "9ce58779-894f-45c7-ac0a-9be9808d25f2",
+  "tables": {
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "activity": {
+      "name": "activity",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "daily_goal": {
+          "name": "daily_goal",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "weekly_goal": {
+          "name": "weekly_goal",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "monthly_goal": {
+          "name": "monthly_goal",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "favorite": {
+          "name": "favorite",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "archived": {
+          "name": "archived",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "activity_user_id_user_id_fk": {
+          "name": "activity_user_id_user_id_fk",
+          "tableFrom": "activity",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "activity_category": {
+      "name": "activity_category",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "activity_id": {
+          "name": "activity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "activity_category_activity_id_category_id_unique": {
+          "name": "activity_category_activity_id_category_id_unique",
+          "columns": [
+            "activity_id",
+            "category_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "activity_category_activity_id_activity_id_fk": {
+          "name": "activity_category_activity_id_activity_id_fk",
+          "tableFrom": "activity_category",
+          "tableTo": "activity",
+          "columnsFrom": [
+            "activity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "activity_category_category_id_category_id_fk": {
+          "name": "activity_category_category_id_category_id_fk",
+          "tableFrom": "activity_category",
+          "tableTo": "category",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "category": {
+      "name": "category",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "category_user_id_user_id_fk": {
+          "name": "category_user_id_user_id_fk",
+          "tableFrom": "category",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "time_session": {
+      "name": "time_session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "activity_id": {
+          "name": "activity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stopped_at": {
+          "name": "stopped_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "time_session_activity_id_activity_id_fk": {
+          "name": "time_session_activity_id_activity_id_fk",
+          "tableFrom": "time_session",
+          "tableTo": "activity",
+          "columnsFrom": [
+            "activity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "time_session_user_id_user_id_fk": {
+          "name": "time_session_user_id_user_id_fk",
+          "tableFrom": "time_session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -64,6 +64,13 @@
       "when": 1759422801990,
       "tag": "0008_milky_firestar",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "6",
+      "when": 1778338449449,
+      "tag": "0009_robust_the_leader",
+      "breakpoints": true
     }
   ]
 }

--- a/src/lib/api/daily.remote.ts
+++ b/src/lib/api/daily.remote.ts
@@ -1,6 +1,6 @@
 import { command, getRequestEvent, query } from '$app/server';
 import { activity, activityCategory, category, timeSession } from '$lib/server/db/schema';
-import { and, eq, gte, inArray, isNotNull, lt } from 'drizzle-orm';
+import { and, desc, eq, gte, inArray, isNotNull, lt } from 'drizzle-orm';
 import * as v from 'valibot';
 
 // Get all activities with their categories for the current user (for manual session entry)
@@ -21,7 +21,7 @@ export const getActivitiesForUser = query(
 			})
 			.from(activity)
 			.where(and(eq(activity.userId, userId), eq(activity.archived, false)))
-			.orderBy(activity.name)
+			.orderBy(desc(activity.favorite), activity.name)
 			.all();
 
 		if (activities.length === 0) {

--- a/src/lib/api/data.remote.ts
+++ b/src/lib/api/data.remote.ts
@@ -24,10 +24,12 @@ export const getCategoriesWithActivities = query(
 			.where(eq(category.userId, userId))
 			.all();
 
+		const sortedCategories = [...categories].sort((a, b) => a.name.localeCompare(b.name));
+
 		type ActivityWithCategories = SelectActivity & { categories: SelectCategory[] };
 		type CategoryWithActivities = SelectCategory & { activities: ActivityWithCategories[] };
 
-		if (categories.length === 0) {
+		if (sortedCategories.length === 0) {
 			return [] as CategoryWithActivities[];
 		}
 
@@ -39,13 +41,17 @@ export const getCategoriesWithActivities = query(
 			.all();
 
 		if (userActivities.length === 0) {
-			return categories.map((cat) => ({
+			return sortedCategories.map((cat) => ({
 				...cat,
 				activities: [] as ActivityWithCategories[]
 			})) satisfies CategoryWithActivities[];
 		}
 
-		const activityIds = userActivities.map((item) => item.id);
+		const sortedUserActivities = [...userActivities].sort(
+			(a, b) => Number(b.favorite) - Number(a.favorite) || a.name.localeCompare(b.name)
+		);
+
+		const activityIds = sortedUserActivities.map((item) => item.id);
 
 		// Get all activity-category links for the fetched activities
 		const activityCategoryRows = await locals.db
@@ -69,7 +75,7 @@ export const getCategoriesWithActivities = query(
 			activityCategoryMap.set(row.activityId, assignedCategories);
 		}
 
-		const activitiesWithCategories: ActivityWithCategories[] = userActivities.map(
+		const activitiesWithCategories: ActivityWithCategories[] = sortedUserActivities.map(
 			(userActivity) => ({
 				...userActivity,
 				categories: activityCategoryMap.get(userActivity.id) ?? []
@@ -77,7 +83,7 @@ export const getCategoriesWithActivities = query(
 		);
 
 		// Group activities by category
-		const categoriesWithActivities: CategoryWithActivities[] = categories.map((cat) => {
+		const categoriesWithActivities: CategoryWithActivities[] = sortedCategories.map((cat) => {
 			const categoryActivities = activitiesWithCategories.filter((activity) =>
 				activity.categories.some((c: SelectCategory) => c.id === cat.id)
 			);
@@ -453,6 +459,37 @@ export const updateActivity = command(
 		await getCategoriesWithActivities(userId).refresh();
 
 		return activityUpdate;
+	}
+);
+
+// Archive/unarchive an activity
+export const setActivityFavorite = command(
+	v.object({
+		id: v.pipe(v.number(), v.minValue(1, 'Activity ID must be a positive number')),
+		favorite: v.boolean('Favorite must be a boolean'),
+		userId: v.string()
+	}),
+	async ({ id, favorite, userId }) => {
+		const { locals } = getRequestEvent();
+		const db = locals.db;
+
+		const updatedActivity = await db
+			.update(activity)
+			.set({
+				favorite,
+				updatedAt: new Date()
+			})
+			.where(eq(activity.id, id))
+			.returning()
+			.get();
+
+		if (!updatedActivity || updatedActivity.userId !== userId) {
+			throw new Error('Activity not found or unauthorized');
+		}
+
+		await getCategoriesWithActivities(userId).refresh();
+
+		return updatedActivity;
 	}
 );
 

--- a/src/lib/components/tracker/ActivityCard.svelte
+++ b/src/lib/components/tracker/ActivityCard.svelte
@@ -1,12 +1,12 @@
 <script lang="ts">
-	import { archiveActivity, deleteActivity } from '$lib/api/data.remote';
+	import { archiveActivity, deleteActivity, setActivityFavorite } from '$lib/api/data.remote';
 	import { ActivityStatisticsDrawer } from '$lib/components/stats';
 	import { Button } from '$lib/components/ui/button';
 	import * as ContextMenu from '$lib/components/ui/context-menu';
 	import * as Dialog from '$lib/components/ui/dialog';
 	import { Label } from '$lib/components/ui/label';
 	import type { ActivityWithOptionalCategories } from '$lib/types';
-	import { Archive, ChartBar, Pause, PencilLine, Play, Trash2 } from '@lucide/svelte';
+	import { Archive, ChartBar, Pause, PencilLine, Play, Star, Trash2 } from '@lucide/svelte';
 	import { toast } from 'svelte-sonner';
 	import EditActivity from './EditActivity.svelte';
 
@@ -14,10 +14,9 @@
 		activity: ActivityWithOptionalCategories;
 		categoryColor: string;
 		categoryName: string;
-		onActivitySelect?: (categoryName: string, activityName: string) => void;
+		onActivitySelect?: (activityId: number, categoryName: string, activityName: string) => void;
 		userId?: string;
-		currentCategory?: string;
-		currentActivity?: string;
+		currentActivityId?: number | null;
 	}
 
 	let {
@@ -26,8 +25,7 @@
 		categoryName,
 		onActivitySelect,
 		userId = '',
-		currentCategory,
-		currentActivity
+		currentActivityId
 	}: Props = $props();
 
 	let editActivityOpen = $state(false);
@@ -36,12 +34,13 @@
 	let statisticsOpen = $state(false);
 	let isDeleting = $state(false);
 	let isArchiving = $state(false);
+	let isUpdatingFavorite = $state(false);
 
 	// Check if this activity is currently running
-	let isRunning = $derived(currentCategory === categoryName && currentActivity === activity.name);
+	let isRunning = $derived(currentActivityId === activity.id);
 
 	function handleClick() {
-		onActivitySelect?.(categoryName, activity.name);
+		onActivitySelect?.(activity.id, categoryName, activity.name);
 	}
 
 	// Handle modify activity
@@ -57,6 +56,32 @@
 	// Handle delete activity
 	function handleDeleteActivity() {
 		deleteDialogOpen = true;
+	}
+
+	async function handleToggleFavorite() {
+		if (!userId || isUpdatingFavorite) return;
+
+		isUpdatingFavorite = true;
+		const nextFavoriteState = !activity.favorite;
+
+		try {
+			await setActivityFavorite({
+				id: activity.id,
+				favorite: nextFavoriteState,
+				userId
+			});
+
+			toast.success(
+				nextFavoriteState
+					? `"${activity.name}" added to favorites`
+					: `"${activity.name}" removed from favorites`
+			);
+		} catch (error) {
+			console.error('Failed to update favorite activity:', error);
+			toast.error('Failed to update favorites');
+		} finally {
+			isUpdatingFavorite = false;
+		}
 	}
 
 	// Confirm archive
@@ -124,6 +149,9 @@
 			<div class="grid gap-1 font-normal">
 				<div class="text-sm font-medium">
 					{activity.name}
+					{#if activity.favorite}
+						<Star class="ml-1 inline h-3.5 w-3.5 fill-amber-400 text-amber-400" />
+					{/if}
 					{#if activity.archived}
 						<span class="ml-1 text-xs text-muted-foreground">(Archived)</span>
 					{/if}
@@ -152,6 +180,10 @@
 		<ContextMenu.Item onclick={() => (statisticsOpen = true)}>
 			<ChartBar class="mr-2 h-4 w-4" />
 			Statistics
+		</ContextMenu.Item>
+		<ContextMenu.Item onclick={handleToggleFavorite} disabled={isUpdatingFavorite}>
+			<Star class="mr-2 h-4 w-4" />
+			{activity.favorite ? 'Remove from favorites' : 'Add to favorites'}
 		</ContextMenu.Item>
 		<ContextMenu.Item onclick={handleArchiveActivity}>
 			<Archive class="mr-2 h-4 w-4" />

--- a/src/lib/components/tracker/ActivityList.svelte
+++ b/src/lib/components/tracker/ActivityList.svelte
@@ -13,13 +13,12 @@
 
 	interface Props {
 		activities: ActivityWithContext[];
-		onActivitySelect?: (categoryName: string, activityName: string) => void;
+		onActivitySelect?: (activityId: number, categoryName: string, activityName: string) => void;
 		userId?: string;
-		currentCategory?: string;
-		currentActivity?: string;
+		currentActivityId?: number | null;
 	}
 
-	let { activities, onActivitySelect, userId, currentCategory, currentActivity }: Props = $props();
+	let { activities, onActivitySelect, userId, currentActivityId }: Props = $props();
 
 	// Search state
 	let searchQuery = $state('');
@@ -112,8 +111,7 @@
 						categoryName={item.categoryName}
 						{onActivitySelect}
 						{userId}
-						{currentCategory}
-						{currentActivity}
+						{currentActivityId}
 					/>
 				{/each}
 			</div>

--- a/src/lib/components/tracker/FavoriteActivities.svelte
+++ b/src/lib/components/tracker/FavoriteActivities.svelte
@@ -1,0 +1,123 @@
+<script lang="ts">
+	import { Input } from '$lib/components/ui/input';
+	import { Separator } from '$lib/components/ui/separator';
+	import type { SelectActivity } from '$lib/server/db/schema';
+	import { Search, Star, X } from '@lucide/svelte';
+	import ActivityCard from './ActivityCard.svelte';
+
+	interface ActivityWithContext {
+		activity: SelectActivity;
+		categoryColor: string;
+		categoryName: string;
+	}
+
+	interface Props {
+		activities: ActivityWithContext[];
+		onActivitySelect?: (activityId: number, categoryName: string, activityName: string) => void;
+		userId?: string;
+		currentActivityId?: number | null;
+	}
+
+	let { activities, onActivitySelect, userId, currentActivityId }: Props = $props();
+
+	let searchQuery = $state('');
+
+	const allFavorites = $derived(activities.filter((item) => !item.activity.archived));
+
+	const visibleFavorites = $derived.by(() => {
+		if (!searchQuery.trim()) {
+			return allFavorites;
+		}
+
+		const query = searchQuery.toLowerCase().trim();
+		return allFavorites.filter(
+			(item) =>
+				item.activity.name.toLowerCase().includes(query) ||
+				item.activity.icon.includes(query) ||
+				item.categoryName.toLowerCase().includes(query)
+		);
+	});
+
+	function clearSearch() {
+		searchQuery = '';
+	}
+
+	function handleKeydown(event: KeyboardEvent) {
+		if (event.key === 'Escape' && searchQuery) {
+			clearSearch();
+			event.preventDefault();
+		}
+	}
+</script>
+
+<Separator class="my-4" />
+<div class="mt-4 space-y-3">
+	<div class="flex items-center justify-between gap-2">
+		<div class="flex items-start gap-2">
+			<div class="rounded-full bg-amber-100 p-2 text-amber-600 dark:bg-amber-500/10 dark:text-amber-400">
+				<Star class="h-4 w-4 fill-current" />
+			</div>
+			<div>
+				<h2 class="text-lg font-semibold text-foreground">Favorites</h2>
+				<p class="text-sm text-muted-foreground">Quick access to your most-used activities</p>
+			</div>
+		</div>
+		<span class="text-xs text-muted-foreground">{visibleFavorites.length} of {allFavorites.length}</span>
+	</div>
+
+	{#if allFavorites.length > 0}
+		<div class="relative px-1">
+			<Search class="absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+			<Input
+				type="text"
+				placeholder="Search favorites... (Esc to clear)"
+				bind:value={searchQuery}
+				class="pr-9 pl-9"
+				onkeydown={handleKeydown}
+			/>
+			{#if searchQuery}
+				<button
+					type="button"
+					onclick={clearSearch}
+					class="absolute top-1/2 right-3 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+					aria-label="Clear search"
+				>
+					<X class="h-4 w-4" />
+				</button>
+			{/if}
+		</div>
+	{/if}
+
+	{#if allFavorites.length === 0}
+		<div class="py-8 text-center">
+			<p class="text-sm text-muted-foreground">No favorite activities yet</p>
+			<p class="mt-1 text-xs text-muted-foreground">
+				Right-click or long-press any activity and add it to favorites.
+			</p>
+		</div>
+	{:else if visibleFavorites.length === 0}
+		<div class="py-6 text-center">
+			<p class="text-sm text-muted-foreground">No favorites match "{searchQuery}"</p>
+			<button
+				type="button"
+				onclick={clearSearch}
+				class="mt-2 text-sm text-primary hover:underline"
+			>
+				Clear search
+			</button>
+		</div>
+	{:else}
+		<div class="grid grid-cols-2 gap-3">
+			{#each visibleFavorites as item (item.activity.id)}
+				<ActivityCard
+					activity={item.activity}
+					categoryColor={item.categoryColor}
+					categoryName={item.categoryName}
+					{onActivitySelect}
+					{userId}
+					{currentActivityId}
+				/>
+			{/each}
+		</div>
+	{/if}
+</div>

--- a/src/lib/components/tracker/index.ts
+++ b/src/lib/components/tracker/index.ts
@@ -7,5 +7,6 @@ export { default as CreateCategory } from './CreateCategory.svelte';
 export { default as EditActivity } from './EditActivity.svelte';
 export { default as EditCategory } from './EditCategory.svelte';
 export { default as EmptyState } from './EmptyState.svelte';
+export { default as FavoriteActivities } from './FavoriteActivities.svelte';
 export { default as FloatingAddButton } from './FloatingAddButton.svelte';
 export { default as Timer } from './Timer.svelte';

--- a/src/lib/server/db/schema.ts
+++ b/src/lib/server/db/schema.ts
@@ -25,6 +25,7 @@ export const activity = sqliteTable('activity', {
 	dailyGoal: integer('daily_goal'), // in minutes
 	weeklyGoal: integer('weekly_goal'), // in minutes
 	monthlyGoal: integer('monthly_goal'), // in minutes
+	favorite: integer('favorite', { mode: 'boolean' }).default(false).notNull(),
 	archived: integer('archived', { mode: 'boolean' }).default(false).notNull(),
 	userId: text('user_id')
 		.notNull()
@@ -134,7 +135,7 @@ export const insertActivitySchema = createInsertSchema(activity, {
 			v.minValue(1, 'Monthly goal must be at least 1 minute')
 		)
 	),
-
+	favorite: v.optional(v.boolean('Favorite must be a boolean')),
 	archived: v.optional(v.boolean('Archived must be a boolean')),
 	userId: v.pipe(v.string('User ID must be a string'), v.minLength(1, 'User ID is required'))
 });

--- a/src/lib/stores/index.ts
+++ b/src/lib/stores/index.ts
@@ -1,4 +1,5 @@
 export { selectionPersistedState, selectionStore, type SelectionState } from './selection';
+export { trackerTabPersistedState, type TrackerTab } from './tracker-view';
 export {
 	calculateElapsedTime,
 	restoreTimerFromDatabase,

--- a/src/lib/stores/tracker-view.ts
+++ b/src/lib/stores/tracker-view.ts
@@ -1,0 +1,14 @@
+import { PersistedState } from 'runed';
+
+export type TrackerTab = 'activities' | 'favorites';
+
+const defaultTrackerTab: TrackerTab = 'activities';
+
+export const trackerTabPersistedState = new PersistedState<TrackerTab>(
+	'ordo-tracker-tab',
+	defaultTrackerTab,
+	{
+		storage: 'local',
+		syncTabs: true
+	}
+);

--- a/src/routes/(app)/+page.svelte
+++ b/src/routes/(app)/+page.svelte
@@ -12,18 +12,27 @@
 		CreateActivity,
 		CreateCategory,
 		EmptyState,
+		FavoriteActivities,
 		FloatingAddButton,
 		Timer
 	} from '$lib/components/tracker';
 	import { ScrollArea } from '$lib/components/ui/scroll-area';
 	import { Separator } from '$lib/components/ui/separator';
-	import { restoreTimerFromDatabase, selectionStore, timerStore } from '$lib/stores';
+	import * as Tabs from '$lib/components/ui/tabs';
+	import {
+		restoreTimerFromDatabase,
+		selectionStore,
+		timerStore,
+		trackerTabPersistedState,
+		type TrackerTab
+	} from '$lib/stores';
 	import { onMount } from 'svelte';
 	import { toast } from 'svelte-sonner';
 
 	// State for create dialogs triggered from empty states
 	let showCreateCategory = $state(false);
 	let showCreateActivity = $state(false);
+	let activeTab = $state<TrackerTab>(trackerTabPersistedState.current);
 
 	// Get user from page data
 	const user = $derived(page.data?.user);
@@ -149,7 +158,8 @@
 					category: { name: categoryName }
 				}))
 			)
-			.then((session) => {
+			.then(async (sessionPromise) => {
+				const session = await sessionPromise;
 				// Update the timer store with the real session ID once server responds
 				timerStore.updateSessionId(session.id);
 			})
@@ -191,70 +201,20 @@
 	}
 
 	// Handle activity selection
-	function handleActivitySelect(categoryName: string, activityName: string) {
+	function handleActivitySelect(activityId: number, categoryName: string, activityName: string) {
 		if (!user?.id) return;
 
 		// Check if this is the currently running activity (toggle behavior)
-		if (
-			timerStore.current.isActive &&
-			timerStore.current.categoryName === categoryName &&
-			timerStore.current.activityName === activityName
-		) {
-			// Stop the timer if clicking the same activity
+		if (timerStore.current.isActive && timerStore.current.activityId === activityId) {
 			stopTimer();
 			return;
 		}
 
-		// Stop any existing timer first
 		if (timerStore.current.isActive) {
 			stopTimer();
 		}
 
-		// Get categories data to find the activity ID
-		const categoriesData = categoriesQuery?.current;
-		if (!categoriesData) {
-			console.error('Categories not loaded');
-			return;
-		}
-
-		// We need to find the activity ID. Since we have multiple categories selected,
-		// we can search through the selectedActivities derived store or the raw categories.
-		// Searching raw categories is safer as it covers all possibilities.
-
-		let foundActivityId = -1;
-
-		// Find the activity in the categories
-		for (const cat of categoriesData) {
-			if (cat.name === categoryName) {
-				const act = cat.activities.find((a) => a.name === activityName);
-				if (act) {
-					foundActivityId = act.id;
-					break;
-				}
-			}
-		}
-
-		if (foundActivityId === -1) {
-			// Fallback: try to find by name across all categories if category name match failed
-			// This handles edge cases where category name might be ambiguous or display-only
-			for (const cat of categoriesData) {
-				const act = cat.activities.find((a) => a.name === activityName);
-				if (act) {
-					foundActivityId = act.id;
-					// Update category name to the one where we found it
-					categoryName = cat.name;
-					break;
-				}
-			}
-		}
-
-		if (foundActivityId === -1) {
-			console.error('Activity not found:', activityName);
-			return;
-		}
-
-		// Start timer with the found activity
-		startTimer(foundActivityId, categoryName, activityName);
+		startTimer(activityId, categoryName, activityName);
 	}
 
 	// Sync timer state with database
@@ -328,6 +288,46 @@
 		})();
 	});
 
+	$effect(() => {
+		if (trackerTabPersistedState.current !== activeTab) {
+			trackerTabPersistedState.current = activeTab;
+		}
+	});
+
+	$effect(() => {
+		if (activeTab !== trackerTabPersistedState.current) {
+			activeTab = trackerTabPersistedState.current;
+		}
+	});
+
+	const favoriteActivities = $derived.by(() => {
+		const currentCategories = categoriesQuery?.current;
+		if (!currentCategories) return [];
+
+		const favoritesMap: Record<
+			number,
+			{
+				activity: (typeof currentCategories)[0]['activities'][0];
+				categoryColor: string;
+				categoryName: string;
+			}
+		> = {};
+
+		for (const category of currentCategories) {
+			for (const activity of category.activities) {
+				if (activity.archived || !activity.favorite || favoritesMap[activity.id]) continue;
+
+				favoritesMap[activity.id] = {
+					activity,
+					categoryColor: category.color,
+					categoryName: category.name
+				};
+			}
+		}
+
+		return Object.values(favoritesMap).sort((a, b) => a.activity.name.localeCompare(b.activity.name));
+	});
+
 	// Check if there are any non-archived activities in selected categories
 	const hasActivitiesInSelection = $derived(
 		selectedActivities.some((item) => !item.activity.archived)
@@ -358,35 +358,56 @@
 		<!-- Empty state for new users with no categories -->
 		<EmptyState type="no-categories" onCreateCategory={() => (showCreateCategory = true)} />
 	{:else}
-		<!-- Categories -->
-		<CategorySelector
-			categories={categoriesQuery?.current || []}
-			selectedCategoryIds={selectionStore.current.selectedCategoryIds}
-			filterMode={selectionStore.current.filterMode}
-			onFilterModeChange={handleFilterModeChange}
-			onClearSelection={handleClearCategorySelection}
-			onCategoryChange={handleCategorySelection}
-			loading={categoriesQuery?.loading || false}
-			error={categoriesQuery?.error}
-			userId={user?.id || ''}
-		/>
+		<Tabs.Root bind:value={activeTab} class="mt-4 w-full">
+			<Tabs.List class="grid w-full grid-cols-2 rounded-lg bg-muted p-1">
+				<Tabs.Trigger value="activities" class="rounded-md data-[state=active]:bg-background">
+					Activities
+				</Tabs.Trigger>
+				<Tabs.Trigger value="favorites" class="rounded-md data-[state=active]:bg-background">
+					Favorites
+				</Tabs.Trigger>
+			</Tabs.List>
 
-		<!-- Activities for Selected Categories -->
-		{#if selectionStore.current.selectedCategoryIds.length === 0}
-			<Separator class="my-4" />
-			<EmptyState type="no-selection" />
-		{:else if !hasActivitiesInSelection}
-			<Separator class="my-4" />
-			<EmptyState type="no-activities" onCreateActivity={() => (showCreateActivity = true)} />
-		{:else}
-			<ActivityList
-				activities={selectedActivities}
-				onActivitySelect={handleActivitySelect}
-				userId={user?.id || ''}
-				currentCategory={timerStore.current.categoryName}
-				currentActivity={timerStore.current.activityName}
-			/>
-		{/if}
+			<Tabs.Content value="activities" class="mt-0">
+				<!-- Categories -->
+				<CategorySelector
+					categories={categoriesQuery?.current || []}
+					selectedCategoryIds={selectionStore.current.selectedCategoryIds}
+					filterMode={selectionStore.current.filterMode}
+					onFilterModeChange={handleFilterModeChange}
+					onClearSelection={handleClearCategorySelection}
+					onCategoryChange={handleCategorySelection}
+					loading={categoriesQuery?.loading || false}
+					error={categoriesQuery?.error}
+					userId={user?.id || ''}
+				/>
+
+				<!-- Activities for Selected Categories -->
+				{#if selectionStore.current.selectedCategoryIds.length === 0}
+					<Separator class="my-4" />
+					<EmptyState type="no-selection" />
+				{:else if !hasActivitiesInSelection}
+					<Separator class="my-4" />
+					<EmptyState type="no-activities" onCreateActivity={() => (showCreateActivity = true)} />
+				{:else}
+					<ActivityList
+						activities={selectedActivities}
+						onActivitySelect={handleActivitySelect}
+						userId={user?.id || ''}
+						currentActivityId={timerStore.current.activityId}
+					/>
+				{/if}
+			</Tabs.Content>
+
+			<Tabs.Content value="favorites" class="mt-0">
+				<FavoriteActivities
+					activities={favoriteActivities}
+					onActivitySelect={handleActivitySelect}
+					userId={user?.id || ''}
+					currentActivityId={timerStore.current.activityId}
+				/>
+			</Tabs.Content>
+		</Tabs.Root>
 	{/if}
 </ScrollArea>
 


### PR DESCRIPTION
- Introduced a new `favorite` column in the `activity` table to track favorite activities.
- Implemented API command `setActivityFavorite` to update the favorite status of activities.
- Created `FavoriteActivities` component to display a list of favorite activities with search functionality.
- Updated `ActivityCard` to allow users to toggle favorite status.
- Modified `ActivityList` and `index.ts` to include the new `FavoriteActivities` component.
- Enhanced the main page to support tab navigation between activities and favorites.
- Updated relevant stores and schemas to accommodate the new favorite functionality.